### PR TITLE
Import vim native menus to Venu

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Or use any other vim plugin manager.
 * **Merging of menus submenus**: If a menu is registered and has the same `name` as an already registered menu and there is a filetype collision (meaning both submenus or items have at least one filetype in common) then its contents including its submenus are merged together. This allows creating very general commands within a menu which can be extended by more specific commands for various filetypes.
 * **Filetype specific commands**: Each menu and menu item can be assigned a filetype or a list of filetypes. This allows creating different menus for different filetypes.
 * **Position preference and ordering priority**: Each menu and menu item can be assigned a preference for its position in the menu and an ordering priority. Positions are not guaranteed. If a position is assigned to more than one entry then all entries for that position are ordered by each entry's priority and are listed consecutively. This may result in subsequent entries not meeting their preferred positions. Empty entries may appear in case a menu or menu item has a position which is higher than one above the previous menu or menu item.
+* **Import of native vim menus**: Native menus can be imported to Venu. See [documentation](./docs/import.md) for more details.
 
 ## Example Usage
 

--- a/autoload/venu/native.vim
+++ b/autoload/venu/native.vim
@@ -1,0 +1,191 @@
+" a:key is needed though unused, as this function is called by vim's filter()
+function! venu#native#defaultFilter(key, menu) abort
+  if a:menu.is_separator
+    return 0
+  endif
+
+  if len(a:menu.submenus) > 0
+    call filter(a:menu.submenus, function("venu#native#defaultFilter"))
+    return len(a:menu.submenus) > 0
+  endif
+
+  return has_key(a:menu.mode, "n")
+endfunction
+
+let s:menu_filter = get(g:, "venu_native_menu_filter",
+                      \ function("venu#native#defaultFilter"))
+let s:menu_cmd    = get(g:, "venu_native_menu_cmd", "amenu")
+
+if type(s:menu_filter) != v:t_func
+  echoerr "Type of g:venu_menu_filter must be Funcref"
+endif
+
+function! s:ParseMenuLine(line) abort
+  let l:until_eol_regex = '(.{-})\s*\r?$'
+  let l:menu_regex = '\v^( *)(-?\d+) ' . l:until_eol_regex
+  let l:cmd_regex = '\v^( *)([a-z])([*& ][s ][- ]) ' . l:until_eol_regex
+  let l:match = matchlist(a:line, l:menu_regex)
+  if len(l:match) > 0
+    return [len(l:match[1]), l:match[2], l:match[3]]
+  endif
+
+  let l:match = matchlist(a:line, l:cmd_regex)
+  if len(l:match) == 0
+    return []
+  endif
+  return [len(l:match[1]), l:match[2], l:match[3], l:match[4]]
+endfunction
+
+" Extract <TAB>=^I separated description from name if there exists one
+function! s:ExtractDesc(name) abort
+  let l:tmp = matchlist(a:name, '\v^(.{-})\^I(.{-})$')
+  if len(l:tmp) == 0
+    let l:name = a:name
+    let l:desc = ''
+  else
+    let l:name = l:tmp[1]
+    let l:desc = l:tmp[2]
+  endif
+  return [l:name, l:desc]
+endfunction
+
+" Extract &Shortcut and replace escaped ampersands (&&).
+function! s:ExtractShortcut(name) abort
+  " These are not some curse words, just some regex to match first unescaped &.
+  let l:tmp = matchend(a:name, '\v(\&)@<!%(\&\&)*(\&)(\&)@!')
+  if l:tmp < 0
+    let l:shortcut = ''
+    let l:name = a:name
+  else
+    let l:shortcut = a:name[l:tmp]
+    let l:name = substitute(
+    \   strpart(a:name, 0, l:tmp - 1).strpart(a:name, l:tmp),
+    \   "&&", "&", "g"
+    \ )
+  endif
+  return [l:name, l:shortcut]
+endfunction
+
+function! venu#native#parseMenu(...) abort
+  if a:0 == 0
+    let l:menu_cmd = s:menu_cmd
+  elseif a:0 == 1
+    let l:menu_cmd = a:1
+  else
+    echoerr "Only optional argument allowed is menu command."
+  endif
+  let l:menu_str = execute(l:menu_cmd)
+  let l:root = []
+  let l:prevdepth = 0
+
+  for l:line in split(l:menu_str, '\n')
+    let l:line = s:ParseMenuLine(l:line)
+
+    " If line matches a menu title or a menu command
+    if len(l:line) > 0
+      " If line matches a menu title
+      if match(l:line[1], '\v^\d+$') == 0
+        let l:indent   = l:line[0]
+        let l:depth    = l:indent / 2
+        let l:priority = str2nr(l:line[1])
+
+        let l:tmp  = s:ExtractDesc(l:line[2])
+        let l:name = l:tmp[0]
+        let l:desc = l:tmp[1]
+
+        let l:tmp      = s:ExtractShortcut(l:name)
+        let l:name     = l:tmp[0]
+        let l:shortcut = l:tmp[1]
+
+        let l:menu = {
+              \  'name': l:name,
+              \  'desc': l:desc,
+              \  'priority': l:priority,
+              \  'shortcut': l:shortcut,
+              \  'submenus': [],
+              \  'mode': {},
+              \  'is_separator': l:name =~ '^-.*-$',
+              \}
+
+        if l:depth == 0
+          call add(l:root, l:menu)
+          let l:stack = []
+        elseif l:depth > l:prevdepth
+          call assert_true(l:depth - l:prevdepth == 1)
+          call add(l:stack[-1].submenus, l:menu)
+        elseif l:depth == l:prevdepth
+          call remove(l:stack, -1)
+          call add(l:stack[-1].submenus, l:menu)
+        else " l:depth < l:prevdepth
+          call remove(l:stack, -(l:prevdepth - l:depth + 1), -1)
+          call add(l:stack[-1].submenus, l:menu)
+        endif
+
+        call add(l:stack, l:menu)
+        let l:prevdepth = l:depth
+
+      " Else (if line matches a menu command)
+      else
+        " Ignore l:line[0] (indent) since it's not used
+        let l:mode      = l:line[1]
+        let l:mode_flag = l:line[2]
+        let l:cmd       = l:line[3]
+        let l:stack[-1].mode[l:mode] = {'flag': l:mode_flag, 'cmd': l:cmd}
+      endif
+    endif
+  endfor
+  return l:root
+endfunction
+
+function! venu#native#createVenuFromMenu(menu) abort
+  " let l:venu = venu#create(a:menu.name, 0, a:menu.priority)
+  let l:venu = venu#create(a:menu.name)
+
+  for l:submenu in a:menu.submenus
+    if len(l:submenu.submenus) > 0
+      let l:subvenu = venu#native#createVenuFromMenu(l:submenu)
+      call venu#addItem(l:venu, l:submenu.name, l:subvenu)
+    elseif has_key(l:submenu.mode, "n")
+      " Dirty trick adapted from: https://stackoverflow.com/a/16007121
+      " Necessary to escape special key characters (<CR>, <ESC> etc.)
+      let l:cmd = eval('"'. escape(l:submenu.mode["n"].cmd, '\"<') . '"')
+      call venu#addItem(l:venu, l:submenu.name, "normal " . l:cmd)
+    endif
+  endfor
+
+  return l:venu
+endfunction
+
+function! venu#native#import(...) abort
+  if a:0 == 0
+    let l:Filter = s:menu_filter
+  elseif a:0 == 1
+    let l:Filter = a:1
+  else
+    echoerr "Only optional argument allowed is filter."
+  endif
+  let l:menus = venu#native#parseMenu()
+  call filter(l:menus, l:Filter)
+  for l:menu in l:menus
+    call venu#register(venu#native#createVenuFromMenu(l:menu))
+  endfor
+endfunction
+
+function! s:DebugTraverse(entry, indent) abort
+  let l:spaces = ''
+  let l:i = 0
+  while l:i < a:indent
+    let l:spaces .= ' '
+    let l:i += 1
+  endwhile
+
+  for l:entry in a:entry
+    echo l:spaces."name='".l:entry.name
+          \ ."', desc='".l:entry.desc
+          \ ."', scut='".l:entry.shortcut
+          \ ."', prio=".string(l:entry.priority)
+          \ .", is_sep=".string(l:entry.is_separator)
+          \ .", mode=".string(l:entry.mode)
+    call s:DebugTraverse(l:entry.submenus, a:indent + 1)
+  endfor
+endfunction

--- a/docs/import.md
+++ b/docs/import.md
@@ -1,0 +1,116 @@
+# Importing vim menus to V̂enu
+
+V̂enu can import vim's native menu entries (`:help menu`). This document
+provides reference for `vim#native` module used for this purpose.
+
+## Functions
+
+---
+
+```vim
+venu#native#import([menu_filter])
+```
+
+Imports VIM native menu entries to V̂enu.
+
+Optionally takes a callback function `menu_filter` used for filtering which
+entries to import and modifying menu entries before they get imported. By
+default, the value of `g:venu_native_menu_filter` is used if provided,
+otherwise `venu#native#defaultFilter` is used. See [Filtering Menus](#filtering-menus)
+section for more details about menu filters.
+
+---
+
+```vim
+venu#native#parseMenu([menu_cmd])
+```
+
+Parses output of vim menu printing command and returns a list of menu
+dictionaries.
+
+Optional argument `menu_cmd` controls which command is used to retrieve vim's
+native menu. By default, the value of `g:venu_native_menu_cmd` is used if provided,
+otherwise `amenu` is used.
+
+Note that returned menu dictionaries have a different format than those used by
+V̂enu (see `venu#native#createVenuFromMenu`). Menu dictionaries returned by this function have these keys:
+
+- `name`: Name of the menu entry. It doesn't include right aligned text
+(provided by `desc`) or ampersand preceding the shortcut character (provided
+by `shortcut`).
+- `desc`: Right aligned text of the menu entry, if there is one. This is the
+portion following `<TAB>` special character in the menu entry name.
+- `priority`: Priority of the menu entry. If two menus are in the same level,
+the one with greater priority value will be closer to the right side (see `:help
+menu-property`). This is similar to V̂enu's use of priority where menus with greater
+priority values are rendered closer to the bottom.
+- `shortcut`: Shortcut letter denoted with a preceding ampersand (&) in the
+menu name.
+- `submenus`: A list of menu entry dictionaries for submenus.
+A submenu entry has the same keys as its parent menu (i.e. this list).
+- `mode`: A dictionary of modes (`n`, `v`, `i`...) defined for this menu. Each
+mode value also keeps a dictionary where `flag` keeps the flag of mode and
+`cmd` keeps the command that will be executed when the menu entry is selected.
+- `is_separator`: Whether the menu is just a seperator. vim treats menus with
+names beginning and ending with dash (-) as separators.
+
+---
+
+```vim
+venu#native#createVenuFromMenu(menu)
+```
+
+Converts native menu dictionary to V̂enu's dictionary format.
+
+---
+
+```vim
+venu#native#defaultFilter(key, menu)
+```
+
+Recursively removes separators and menus without any commands or submenus. See
+[Filtering Menus](#filtering-menus) section for more details about menu filters.
+
+## Configurations
+
+```vim
+" Default menu filter used for importing
+g:venu_native_menu_filter = function('venu#native#defaultFilter')
+
+" Default menu command used for listing vim native menus
+g:venu_native_menu_cmd = 'amenu'
+```
+
+## Filtering Menus
+
+Menu entries can be filtered (or even modified) before being imported. This is
+done through menu filtering functions. A menu filter function is expected to
+take two arguments: `key`, the index of menu entry, and `menu`, the menu
+dictionary. If the function returns true, `menu` will be imported. `menu`
+argument can be modified inside this function to modify any properties of the
+menu entry before importing. See `venu#native#parseMenu` for all properties
+defined in a menu dictionary.
+
+This function will be called for only menus on the root level. It is left to
+the implementation of this function to traverse over submenus of root menus.
+Note that submenus are accessible and modifiable through `menu.submenus`
+property.
+
+## Example
+
+Import only 'PO-Editing' menu while removing separators and empty submenus it
+may include:
+
+```vim
+function! MyVenuFilter(key, menu)
+  return a:menu.name == 'PO-Editing'
+    \ && venu#native#defaultFilter(a:key, a:menu)
+endfunction
+
+call venu#native#import(function('MyVenuFilter'))
+
+" or:
+"
+" g:venu_native_menu_filter = function('MyVenuFilter')
+" call venu#native#import()
+```


### PR DESCRIPTION
This is work-in-progress.

Currently, `venu#native#list` utility method parses output of `menu` command and returns it as a dictionary.

It probably makes more sense for this dictionary to inherit `vemu`s dictionary structure:
https://github.com/Timoses/vim-venu/blob/4897c60d591d45d246373fbf22c32283d6229a19/autoload/venu.vim#L10-L17

I will update it to do so.