### PR TITLE
Improve extensibility/plugability

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     * [Opening the menu in vim](#opening-the-menu-in-vim)
 * [Documentation](#documentation)
 * [Contribute](#contribute)
+    * [Extending V̂enu](#extending-V̂enu)
 * [The ^ in V̂enu ?](#the--in-V̂enu-)
 * [Alternatives](#alternatives)
 
@@ -148,6 +149,15 @@ Unregisters all menus.
 ## Contribute
 
 If you would like to contribute feel free to create a Pull Request or mention your ideas and problems as an Issue.
+
+### Extending V̂enu
+
+See [developer documentation](./docs/developer.md) if you are interested in customizing the behaviour of V̂enu.
+
+Please contribute your solutions back to the project.
+
+If you require any additional functionality or further elements of V̂enu exposed please [open an issue](https://github.com/Timoses/vim-venu/issues/new).
+
 
 ## The ^ in V̂enu ?
 I personally mapped `:VenuPrint` to the `^` key on a German keyboard which is easily reachable. Hence, the name.

--- a/autoload/venu.vim
+++ b/autoload/venu.vim
@@ -6,29 +6,6 @@ else
     let s:VERSION = readfile(s:venupaths[0].'/version')[0]
 endif
 
-" a menu should have the following structure:
-" {
-"   name: <string>,
-"   pos_pref:
-"       Positional preference. Menus/Items with a higher 'priority' win.
-"       Losers are positioned after winner.
-"       Position preference of '0' means no preference.
-"   priority:
-"       Order and positional priority. Lower numbers have higher priority.
-"       Priority of '0' means no priority.
-"   filetypes: <[<string>, <string>, ...],
-"   items: [
-"    { name: <string>,
-"           Name of the menu.
-"      cmd: <string> or <funcref> or <menu>
-"           Cmd to be executed or menu to be displayed when selecting this
-"           item.
-"      pos_pref: <number>
-"           See above menu property 'pos_pref'.
-"      priority: <number>
-"           See above menu property 'priority'.
-"      filetypes: [<string>, <string>, ...]
-"    }]
 let s:menus=[]
 
 " Optional arguments '...': pos_pref, priority

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,0 +1,46 @@
+# V̂enu developer documentation
+
+## Structure of a menu dictionary
+* **`name`** _(string)_: Name of the menu.
+* **`pos_pref`** _(number)_: Positional preference. Menus/Items with a higher 'priority' win. Losers are positioned after winner. Position preference of '0' means no preference.
+* **`priority`** _(number)_: Order and positional priority. Lower numbers have higher priority. Priority of '0' means no priority.
+* **`filetypes`** _([string, string, ...])_: Filetypes that this menu will be displayed for.
+* **`items`** _([item, item, ...])_: Entries that are displayed for the menu. Each `item` has the following structure:
+    * **`name`** _(string)_: Name of the entry
+    * **`cmd`** _(string | funcref| menu)_: Command to be executed or menu to be displayed when this entry is selected.
+    * **`pos_pref`** _(number)_: Same as `pos_pref` for `menu`.
+    * **`priority`** _(number)_: Same as `priority` for `menu`.
+    * **`filetypes`** _([string, string, ...])_: Filetypes that this item will be displayed for.
+
+
+## Callbacks
+
+V̂enu allows its functionality to be customized via callbacks. Exposed callbacks are described below.
+
+* **`g:venu_print_callback`**: Called when `venu#print` is executed.
+
+    * **Parameters**:
+        * `name`: Name of the menu
+        * `itemsOrMenus`: An array of `item`s or `menu`s to be displayed to the user.
+
+
+* **`g:venu_format_entry_callback`**: Called for each item to be printed.
+
+    This is called by the default `venu_print_callback` and allows customizing the appearance of each printed row/item in the menu. A customized `venu_print_callback` is not required to call this callback function. In that case, this callback is ignored.
+
+    * **Parameters**:
+        * `rowNum`: Number of the row in the menu (i.e. the item's position in the menu)
+        * `entry`: `item` or `menu` to be printed.
+
+    * **Return**: Must return the string of the formatted entry.
+
+
+* **`g:venu_select_callback`**: Called to retrieve the user's selection.
+
+    This is called after the menu has been printed. V̂enu expects it to return an item from `choices` which is either a `menu` or an `item`.
+
+    * **Parameters**:
+        * `choices`: Array of choices. Equals the `itemsOrMenus` passed to `g:venu_print_callback`.
+
+    * **Return**: Must return an element from the choices array.
+


### PR DESCRIPTION
First draft..

Callbacks:
* `s:print(name, itemsOrMenus)`
    * prints the menu, each row is printed using `formatEntry` (in default implementation)
* `s:formatEntry(rowNum, entry)`
* `s:select(choices)`

Use cases:
* custom numbering/lettering of menu entries (idea from https://github.com/Timoses/vim-venu/issues/7)
    * simply add a key `shortcut` to the items or menus when creating them
    * use `formatEntry` to print that shortcut
    * use `select` to return the selection