### PR TITLE
Adjust selector to allow selection among 10 or more items

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -17,25 +17,56 @@
 
 V̂enu allows its functionality to be customized via callbacks. Exposed callbacks are described below.
 
-* **`g:venu_print_callback`**: Called when `venu#print` is executed.
+
+* **`g:venu_print_callback`** _printCallback_
+
+    Called when `venu#print` is executed.
+
+    The default handler will simply echo the menu. Each entry is formatted as:
+    ```vim
+    " Example entry echoed: '5. Insert table'
+    echo s:formatEntrySelectorCallback(a:itemsOrMenus, l:menuIterator) . '. '
+            \ . s:formatEntryNameCallback(item)
+    ```
 
     * **Parameters**:
         * `name`: Name of the menu
         * `itemsOrMenus`: An array of `item`s or `menu`s to be displayed to the user.
 
 
-* **`g:venu_format_entry_callback`**: Called for each item to be printed.
+* **`g:venu_format_entry_selector_callback`** _formatEntrySelectorCallback_
 
-    This is called by the default `venu_print_callback` and allows customizing the appearance of each printed row/item in the menu. A customized `venu_print_callback` is not required to call this callback function. In that case, this callback is ignored.
+    Called for each item to be printed.
+
+    This is called by the default `venu_print_callback` and is used to prepend each item's name in a row with a selector. The selector should indicate which keys the user has to press to select the item in the row.
+
+    A customized `venu_print_callback` is not required to call this callback function. In that case, this callback is ignored.
 
     * **Parameters**:
-        * `rowNum`: Number of the row in the menu (i.e. the item's position in the menu)
+        * `choices`: Array of choices. Equals the `itemsOrMenus` passed to `g:venu_print_callback`.
+        * `rowNum`: Number of the row in the menu (i.e. the item's position in the menu).
+
+    * **Return**: Must return the string of the selector.
+
+
+
+* **`g:venu_format_entry_name_callback`** _formatEntryNameCallback_
+
+    Called for each item to be printed.
+
+    This is called by the default `venu_print_callback` and allows customizing the appearance of an item's name in each printed row.
+
+    A customized `venu_print_callback` is not required to call this callback function. In that case, this callback is ignored.
+
+    * **Parameters**:
         * `entry`: `item` or `menu` to be printed.
 
-    * **Return**: Must return the string of the formatted entry.
+    * **Return**: Must return the string of the formatted entry's name.
 
 
-* **`g:venu_select_callback`**: Called to retrieve the user's selection.
+* **`g:venu_select_callback`** _selectCallback_
+
+    Called to retrieve the user's selection.
 
     This is called after the menu has been printed. V̂enu expects it to return an item from `choices` which is either a `menu` or an `item`.
 


### PR DESCRIPTION
Fixes #7 (Limitation of single-digit menu points allows only 9 entries)

This commit introduces another callback (formatEntrySelector) which
allows customizing the selector for each item's entry in the menu.

Default approach for displaying menus with more than 9 entries is to use two-digit selectors:
```
11
12
…
19
21
22
…
28
29
31
32
…
```